### PR TITLE
Fix headlines for feature readme's

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A collection of ready-to-use samples for [Ktor](http://ktor.io).
   
 * Small single-feature samples:
   * [async](feature/async/README.md) &mdash; long-running asynchronous computation that happens in a separate thread-pool context.
-  * auth
+  * [auth](feature/auth/README.md) &mdash; using authorization.
   * [post](feature/post/README.md) &mdash; form post and multipart file upload.
   * [sessions](feature/sessions/README.md) &mdash; store information that will be kept between requests. 
   * [custom-feature](feature/custom-feature/README.md) &mdash; implementation of a custom feature.

--- a/feature/guice/README.md
+++ b/feature/guice/README.md
@@ -1,4 +1,4 @@
-# Async
+# Guice
 
 Sample project for [Ktor](http://ktor.io) using 
 [Guice](https://github.com/google/guice) dependency injection framework.

--- a/feature/locations/README.md
+++ b/feature/locations/README.md
@@ -1,4 +1,4 @@
-# Async
+# Locations
 
 Sample project for [Ktor](http://ktor.io) demonstrating _experimental_ locations feature.
 

--- a/feature/metrics/README.md
+++ b/feature/metrics/README.md
@@ -1,4 +1,4 @@
-# Async
+# Metrics
 
 Sample project for [Ktor](http://ktor.io) demonstrating metrics feature.
 


### PR DESCRIPTION
- Fixed several feature readme's that were incorrectly headlined as "Async" instead of their actual titles.
- Added a link to the Auth feature on the main readme.