### PR TITLE
Notes about converting to Google App Engine

### DIFF
--- a/deployment/google-appengine-standard/README.md
+++ b/deployment/google-appengine-standard/README.md
@@ -48,3 +48,10 @@ gradle appengineDeploy
 
 You can checkout deployed version of this sample application at
 https://ktor-sample.appspot.com
+
+
+## Converting to Google App Engine
+
+Make sure you double check your `appengine-config.xml` and `application.conf` carefully. Make sure you remove any `deployment` config from `application.conf` file, otherwise the `Servlet` when running under Google App Enginer will not get it's enviroment configuration correctly.
+
+


### PR DESCRIPTION
If you leave `deployment` block in the `application.conf`, the Google cloud api's won't work as they can't get there `Environment` properties. (I lost a good 8 hours working that out!)