### PR TITLE
Logback Support for Google Cloud Logging

### DIFF
--- a/deployment/google-appengine-standard/build.gradle
+++ b/deployment/google-appengine-standard/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "io.ktor:ktor-server-servlet:$ktor_version"
     compile "io.ktor:ktor-html-builder:$ktor_version"
-    compile "org.slf4j:slf4j-jdk14:$slf4j_version"
+    compile "com.google.cloud:google-cloud-logging-logback:$gce_logback_version"
 
     providedCompile "com.google.appengine:appengine:$appengine_version"
 }

--- a/deployment/google-appengine-standard/src/main/kotlin/HelloApplication.kt
+++ b/deployment/google-appengine-standard/src/main/kotlin/HelloApplication.kt
@@ -1,11 +1,13 @@
 package io.ktor.samples.hello
 
 import io.ktor.application.*
+import io.ktor.features.*
 import io.ktor.html.*
 import io.ktor.routing.*
 import kotlinx.html.*
 
 fun Application.main() {
+    install(CallLogging)
     routing {
         get("/") {
             call.respondHtml {

--- a/deployment/google-appengine-standard/src/main/resources/logback.xml
+++ b/deployment/google-appengine-standard/src/main/resources/logback.xml
@@ -1,0 +1,25 @@
+<configuration>
+    <!-- Stack Driver Appender -->
+    <!-- See Config here: https://cloud.google.com/logging/docs/setup/java#wzxhzdk57wzxhzdk58logback_appender_for_product_name -->
+    <appender name="CLOUD" class="com.google.cloud.logging.logback.LoggingAppender">
+        <!-- Optional : filter logs at or above a level -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <log>application.log</log> <!-- Optional : default java.log -->
+        <flushLevel>WARN</flushLevel> <!-- Optional : default ERROR -->
+    </appender>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="trace">
+        <!-- Add Console output for local dev -->
+        <appender-ref ref="STDOUT"/>
+        <!-- Add Cloud Appender to root output-->
+        <appender-ref ref="CLOUD" />
+    </root>
+
+</configuration>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,9 @@
-kotlin_version = 1.2.40
+kotlin_version = 1.2.51
 ktor_version = 0.9.3
 
 logback_version = 1.2.1
 slf4j_version = 1.7.25
+gce_logback_version = 0.54.0-alpha
 
 proguard_version = 6.0.1
 mockk_version = 1.7.15


### PR DESCRIPTION
This changes from the default SLFJ implementation to the Google Logback SDK, this adds logging to Google Stack Driver when running on Google Cloud and fixes console output when running the development server.