### PR TITLE
gson/jackson: parse json request body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,11 @@
 *.iml
 build
 target
+**/out
+mpp/**
 
 .gradle
 local.properties
 *.lock
 /app/snippets-api
+

--- a/feature/gson/src/GsonApplication.kt
+++ b/feature/gson/src/GsonApplication.kt
@@ -4,15 +4,16 @@ import io.ktor.application.*
 import io.ktor.features.*
 import io.ktor.gson.*
 import io.ktor.http.*
+import io.ktor.request.receiveOrNull
 import io.ktor.response.*
 import io.ktor.routing.*
 import java.text.*
 import java.time.*
 
-data class Model(val name: String, val items: List<Item>, val date: LocalDate = LocalDate.of(2018, 4, 13))
+data class Model(val name: String, val items: MutableList<Item>, val date: LocalDate = LocalDate.of(2018, 4, 13))
 data class Item(val key: String, val value: String)
 
-val model = Model("root", listOf(Item("A", "Apache"), Item("B", "Bing")))
+val model = Model("root", mutableListOf(Item("A", "Apache"), Item("B", "Bing")))
 
 fun Application.main() {
     install(DefaultHeaders)
@@ -35,5 +36,15 @@ fun Application.main() {
             else
                 call.respond(item)
         }
+        post("/v1/upload") {
+            val item = call.receiveOrNull<Item>()
+            if(item == null)
+                call.respond(HttpStatusCode.BadRequest, "You must provide a key and a value")
+            else {
+                model.items += item
+                call.respond("${item.key} uploaded.\n")
+            }
+        }
     }
 }
+

--- a/feature/jackson/src/JacksonApplication.kt
+++ b/feature/jackson/src/JacksonApplication.kt
@@ -7,14 +7,15 @@ import io.ktor.application.*
 import io.ktor.features.*
 import io.ktor.http.*
 import io.ktor.jackson.*
+import io.ktor.request.receiveOrNull
 import io.ktor.response.*
 import io.ktor.routing.*
 import java.time.*
 
-data class Model(val name: String, val items: List<Item>, val date: LocalDate = LocalDate.of(2018, 4, 13))
+data class Model(val name: String, val items: MutableList<Item>, val date: LocalDate = LocalDate.of(2018, 4, 13))
 data class Item(val key: String, val value: String)
 
-val model = Model("root", listOf(Item("A", "Apache"), Item("B", "Bing")))
+val model = Model("root", mutableListOf(Item("A", "Apache"), Item("B", "Bing")))
 
 fun Application.main() {
     install(DefaultHeaders)
@@ -41,5 +42,15 @@ fun Application.main() {
             else
                 call.respond(item)
         }
+        post("/v1/upload") {
+            val item = call.receiveOrNull<Item>()
+            if(item == null)
+                call.respond(HttpStatusCode.BadRequest, "You must provide a key and a value")
+            else {
+                model.items += item
+                call.respond("${item.key} uploaded.\n")
+            }
+        }
     }
 }
+


### PR DESCRIPTION
These changes make it possible for the code to convert the JSON Body in a request to a Item object, and add it to the list in the `/v1/upload` endpoint. Here is a sample CURL command to test:

```
curl -H        "Content-Type: application/json" \
     --request POST \
     --data    "{\"key\": \"D\", \"value\": \"Debian\"}" \
               http://localhost:8080/v1/upload
```