### PR TITLE
Update Ktor version to latest 1.3.1, which includes the files missing from :timeout

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.configureondemand = false
 # versions
 kotlin_version = 1.3.61
 kotlin_native_version = 1.3.61
-ktor_version = 1.3.0
+ktor_version = 1.3.1
 kotlinx_coroutines_version = 1.3.3
 
 logback_version = 1.2.3


### PR DESCRIPTION
The [last commit to `master`](https://github.com/ktorio/ktor-samples/commit/c40d75f4a1e48b5b13ef202691f9f168479dec4e) (#55) broke the build. `:timeout` doesn't compile because these two imports are only available in 1.3.1, not in 1.3.0:
```kotlin
import io.ktor.client.features.HttpTimeout
import io.ktor.client.features.timeout
```