### PR TITLE
Enable parallel build to reduce build times

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ kotlin.code.style = official
 
 # gradle configuration
 org.gradle.configureondemand = false
+org.gradle.parallel = true
 
 # versions
 kotlin_version = 1.3.61


### PR DESCRIPTION
`gradlew build` (including check/test) takes 1 minute 17 seconds with current `master`.
Adding this single line decreases that time to just 14 seconds.

Measured with
```sh
gradlew clean build check -x gradle-maven-test:check -x gradle-maven-test:test -x gradle-maven-test:build
```

Timings don't include any `mvnw` calls. I don't have that on my PATH.

0:14 build scan: https://gradle.com/s/sw2cncnoyeips
1:17 build scan: https://gradle.com/s/ym2ae3e2qviaa