### PR TITLE
Fix kweet/youkube application conf

### DIFF
--- a/generic/samples/kweet/resources/application.conf
+++ b/generic/samples/kweet/resources/application.conf
@@ -4,7 +4,7 @@ ktor {
     }
 
     application {
-        modules = [ KweetApplicationKt.main ]
+        modules = [ io.ktor.samples.kweet.KweetApplicationKt.main ]
     }
 }
 

--- a/generic/samples/youkube/resources/application.conf
+++ b/generic/samples/youkube/resources/application.conf
@@ -5,7 +5,7 @@ ktor {
     }
 
     application {
-        modules = [ YoukubeApplicationKt.main ]
+        modules = [ io.ktor.samples.youkube.YoukubeApplicationKt.main ]
     }
 }
 


### PR DESCRIPTION
I wanted to check out some Ktor samples. I was unable to run the Kweet and Youkube sample applications. To get them running, the fully qualified name of the application needs to be used in the application.conf file. Not sure if I missed anything to get them running w/o the change.