### PR TITLE
Fixed chat sample, upgraded versions

### DIFF
--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -41,19 +41,20 @@ kotlin {
     sourceSets {
         backendMain {
             dependencies {
-                implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31"
-                implementation "io.ktor:ktor-server-netty:2.0.0-eap-256"
-                implementation "io.ktor:ktor-server-websockets:2.0.0-eap-256"
-                implementation "io.ktor:ktor-server-call-logging:2.0.0-eap-256"
-                implementation "io.ktor:ktor-server-default-headers:2.0.0-eap-256"
-                implementation "io.ktor:ktor-server-sessions:2.0.0-eap-256"
-                implementation "ch.qos.logback:logback-classic:1.2.6"
+//                implementation "io.github.microutils:kotlin-logging-jvm:2.1.20"
+                implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+                implementation "io.ktor:ktor-server-netty:$ktor_eap_version"
+                implementation "io.ktor:ktor-server-websockets:$ktor_eap_version"
+                implementation "io.ktor:ktor-server-call-logging:$ktor_eap_version"
+                implementation "io.ktor:ktor-server-default-headers:$ktor_eap_version"
+                implementation "io.ktor:ktor-server-sessions:$ktor_eap_version"
+                implementation "ch.qos.logback:logback-classic:1.2.11"
             }
         }
 
         backendTest {
             dependencies {
-                implementation "io.ktor:ktor-server-test-host:2.0.0-eap-256"
+                implementation "io.ktor:ktor-server-test-host:$ktor_eap_version"
                 implementation "org.jetbrains.kotlin:kotlin-test"
             }
         }
@@ -61,9 +62,9 @@ kotlin {
         frontendMain {
             dependencies {
                 implementation "org.jetbrains.kotlin:kotlin-stdlib-js"
-                implementation "io.ktor:ktor-client-websockets:2.0.0-eap-256"
-                implementation "io.ktor:ktor-client-js:2.0.0-eap-256"
-                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:1.5.2-native-mt"
+                implementation "io.ktor:ktor-client-websockets:$ktor_eap_version"
+                implementation "io.ktor:ktor-client-js:$ktor_eap_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$kotlinx_version"
             }
         }
     }

--- a/chat/gradle.properties
+++ b/chat/gradle.properties
@@ -1,0 +1,3 @@
+kotlin_version=1.6.10
+kotlinx_version=1.6.0
+ktor_eap_version=2.0.0-eap-359

--- a/chat/src/backendMain/kotlin/io/ktor/samples/chat/backend/ChatApplication.kt
+++ b/chat/src/backendMain/kotlin/io/ktor/samples/chat/backend/ChatApplication.kt
@@ -1,11 +1,12 @@
 package io.ktor.samples.chat.backend
 
-import io.ktor.http.cio.websocket.*
+import io.ktor.websocket.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.http.content.*
 import io.ktor.server.netty.*
-import io.ktor.server.plugins.*
+import io.ktor.server.plugins.callloging.*
+import io.ktor.server.plugins.defaultheaders.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.server.websocket.*

--- a/chat/src/backendMain/kotlin/io/ktor/samples/chat/backend/ChatServer.kt
+++ b/chat/src/backendMain/kotlin/io/ktor/samples/chat/backend/ChatServer.kt
@@ -1,6 +1,6 @@
 package io.ktor.samples.chat.backend
 
-import io.ktor.http.cio.websocket.*
+import io.ktor.websocket.*
 import kotlinx.coroutines.channels.*
 import java.util.*
 import java.util.concurrent.*

--- a/chat/src/backendMain/resources/application.conf
+++ b/chat/src/backendMain/resources/application.conf
@@ -5,7 +5,7 @@ ktor {
     }
 
     application {
-        modules = [ io.ktor.samples.chat.ChatApplicationKt.main ]
+        modules = [ io.ktor.samples.chat.backend.ChatApplicationKt.main ]
     }
 }
 

--- a/chat/src/frontendMain/kotlin/main.kt
+++ b/chat/src/frontendMain/kotlin/main.kt
@@ -5,7 +5,7 @@ package io.ktor.samples.chat.frontend
 import io.ktor.client.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.http.*
-import io.ktor.http.cio.websocket.*
+import io.ktor.websocket.*
 import kotlinx.browser.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*


### PR DESCRIPTION
The `chat` example stopped working. This PR changes:

- version upgrades (kotlin, ktor EAP, kotlinx, logging)
- ktor.websocket (package name changed)
- migrate integration test