### PR TITLE
KTOR-4979 Migrate the HttpBin sample to a new testing API

### DIFF
--- a/httpbin/README.md
+++ b/httpbin/README.md
@@ -1,6 +1,6 @@
 # HttpBin
 
-HttpBin application implementing (large parts of) [httpbin(1)](https://httpbin.org/) HTTP request & response service.
+HttpBin application that implements (large parts of) [httpbin(1)](https://httpbin.org/) HTTP request & response service.
 
 ## Running
 

--- a/httpbin/build.gradle
+++ b/httpbin/build.gradle
@@ -43,3 +43,9 @@ dependencies {
     testImplementation 'io.ktor:ktor-server-test-host-jvm:2.1.2'
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
+

--- a/httpbin/request.http
+++ b/httpbin/request.http
@@ -1,0 +1,20 @@
+POST http://localhost:8080/post
+Content-Type: text/plain
+
+Hello, world!
+
+###
+POST http://localhost:8080/post
+Content-Type: application/x-www-form-urlencoded
+
+username=JetBrains&email=example@jetbrains.com&password=foobar&confirmation=foobar
+
+###
+POST http://0.0.0.0:8080/post
+Content-Type: application/json
+
+{
+  "id": 3,
+  "firstName" : "Jet",
+  "lastName": "Brains"
+}

--- a/httpbin/src/HttpBinApplication.kt
+++ b/httpbin/src/HttpBinApplication.kt
@@ -57,7 +57,7 @@ fun Application.main() {
     // For each GET header, adds an automatic HEAD handler (checks the headers of the requests
     // without actually getting the payload to be more efficient about resources)
     install(AutoHeadResponse)
-    // Based on the Accept header, allows to reply with arbitrary objects converting them into JSON
+    // Based on the Accept header, allows replying with arbitrary objects converting them into JSON
     // when the client accepts it.
     install(ContentNegotiation) {
         register(ContentType.Application.Json, GsonConverter(gson))
@@ -84,8 +84,8 @@ fun Application.main() {
     }
 
     // Folder from the File System that we are going to use to serve static files.
-    val staticfilesDir = File("resources/static")
-    require(staticfilesDir.exists()) { "Cannot find ${staticfilesDir.absolutePath}" }
+    val staticFilesDir = File("resources/static")
+    require(staticFilesDir.exists()) { "Cannot find ${staticFilesDir.absolutePath}" }
 
     // Fake Authorization with user:password "test:test"
     val hashedUserTable = UserHashedTableAuth(
@@ -205,13 +205,13 @@ fun Application.main() {
             }
         }
 
-        // Returns a HTTP status code based on the {status} URL parameter.
+        // Returns an HTTP status code based on the {status} URL parameter.
         get("/status/{status}") {
             val status = call.parameters["status"]?.toInt() ?: 0
             call.respond(HttpStatusCode.fromValue(status))
         }
 
-        // Returns a HTML page with a ul list of [n] links and the [m]th link will be selected (unclickable).
+        // Returns an HTML page with an ul list of [n] links, and the [m]th link will be selected (unclickable).
         get("/links/{n}/{m?}") {
             try {
                 val nbLinks = call.parameters["n"]!!.toInt()
@@ -407,9 +407,9 @@ fun Application.main() {
             resource("postman", "httpbin.postman_collection.json")
             resource("httpbin.js")
 
-            // And for the '/static' path, it will serve the [staticfilesDir].
+            // And for the '/static' path, it will serve the [staticFilesDir].
             route("static") {
-                files(staticfilesDir)
+                files(staticFilesDir)
             }
         }
 

--- a/httpbin/src/HttpBinApplication.kt
+++ b/httpbin/src/HttpBinApplication.kt
@@ -6,10 +6,10 @@ import io.ktor.content.TextContent
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.serialization.gson.*
-import io.ktor.server.http.content.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.html.*
+import io.ktor.server.http.content.*
 import io.ktor.server.plugins.*
 import io.ktor.server.plugins.autohead.*
 import io.ktor.server.plugins.callloging.*
@@ -24,6 +24,7 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.util.*
+import io.ktor.util.date.*
 import io.ktor.util.logging.*
 import kotlinx.coroutines.*
 import java.io.*
@@ -316,7 +317,7 @@ fun Application.main() {
             val params = call.request.queryParameters.names()
             val rawCookies = call.request.cookies.rawCookies
             for (name in params) {
-                call.response.cookies.appendExpired(name, path = "/")
+                call.response.cookies.append(name, "", path = "/", expires = GMTDate.START)
             }
             call.sendHttpBinResponse {
                 clear()

--- a/httpbin/src/HttpBinApplication.kt
+++ b/httpbin/src/HttpBinApplication.kt
@@ -46,8 +46,6 @@ fun Application.main() {
      */
     // This plugin sets a Date and Server headers automatically.
     install(DefaultHeaders)
-    // This plugin enables compression automatically when accepted by the client.
-    install(Compression)
     // Logs all the requests performed
     install(CallLogging)
     // Automatic '304 Not Modified' Responses
@@ -163,18 +161,27 @@ fun Application.main() {
             }
         }
 
-        // @TODO: Forces a gzipped response?
-        get("/gzip") {
-            call.sendHttpBinResponse {
-                gzipped = true
+        // Forces a gzipped response
+        route("/gzip") {
+            install(Compression) {
+                gzip()
+            }
+            get {
+                call.sendHttpBinResponse {
+                    gzipped = true
+                }
             }
         }
 
-        // @TODO: Forces a deflated response?
-        get("/deflate") {
-            // Send header "Accept-Encoding: deflate"
-            call.sendHttpBinResponse {
-                deflated = true
+        // Forces a deflated response
+        route("/deflate") {
+            install(Compression) {
+                deflate()
+            }
+            get {
+                call.sendHttpBinResponse {
+                    deflated = true
+                }
             }
         }
 


### PR DESCRIPTION
Migrated HttpBin tests to a new API and fixed several issues along the way:
- Explicitly set the Java version to 8 as the Gson serializer uses reflection in this project.
- Enabled compression for the `gzip` and `deflate` routes.
- Replaced deprecated `appendExpired` with `append`.
- Added an HTTP file with sample POST requests.