### PR TITLE
Updated run target so chat.js is built before execution

### DIFF
--- a/chat/build.gradle
+++ b/chat/build.gradle
@@ -20,15 +20,10 @@ kotlin {
                 distribution {
                     directory = file("$projectDir/src/backendMain/resources/web")
                 }
+                binaries.executable()
             }
         }
-        jvm('backend') {
-            compilations.main {
-                tasks.named(processResourcesTaskName) {
-                    dependsOn(frontendProcessResources)
-                }
-            }
-        }
+        jvm('backend')
     }
 
     sourceSets.each {
@@ -74,7 +69,8 @@ repositories {
 }
 
 tasks.register("run", JavaExec) {
-    dependsOn(backendJar)
+    dependsOn(frontendBrowserDistribution)
+    dependsOn(backendMainClasses)
     mainClass.set("io.ktor.samples.chat.backend.ChatApplicationKt")
     classpath(configurations.backendRuntimeClasspath, backendJar)
     args = []


### PR DESCRIPTION
Looks like the `binaries.executable()` is required since the IR compiler introduction (according to this https://kotlinlang.org/docs/js-project-setup.html#execution-environments).

I also updated the run task to depend on the required distribution and backend compilation because `frontendProcessResources` didn't produce the script and it doesn't depend on the jar.