### PR TITLE
Bump OpenTelemetry integration example

### DIFF
--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -1,14 +1,14 @@
 # OpenTelemetry-Ktor Demo
 
-[OpenTelemetry](https://opentelemetry.io/) provides support for Ktor with the `KtorClientTracing`and `KtorServerTracing`
+[OpenTelemetry](https://opentelemetry.io/) provides support for Ktor with the `KtorClientTelemetry`and `KtorServerTelemetry`
 plugins for the Ktor client and server respectively. For the source code, see
 the [repository on GitHub](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/ktor).
 
-This project contains examples of how to use the `KtorClientTracing` and `KtorServerTracing` plugins.
+This project contains examples of how to use the `KtorClientTelemetry` and `KtorServerTelemetry` plugins.
 
-You can find examples for the client plugin `KtorClientTracing` in
+You can find examples for the client plugin `KtorClientTelemetry` in
 the [extractions](./client/src/main/kotlin/opentelemetry/ktor/example/plugins/opentelemetry) folder. \
-And you can find examples for the server plugin `KtorServerTracing` in
+And you can find examples for the server plugin `KtorServerTelemetry` in
 the [extractions](./server/src/main/kotlin/opentelemetry/ktor/example/plugins/opentelemetry) folder.
 
 ## Running

--- a/opentelemetry/client/src/main/kotlin/opentelemetry/ktor/example/plugins/opentelemetry/setupClientTelemetry.kt
+++ b/opentelemetry/client/src/main/kotlin/opentelemetry/ktor/example/plugins/opentelemetry/setupClientTelemetry.kt
@@ -3,27 +3,28 @@ package opentelemetry.ktor.example.plugins.opentelemetry
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.http.*
-import io.opentelemetry.instrumentation.ktor.v3_0.client.KtorClientTracing
+import io.opentelemetry.instrumentation.ktor.v2_0.common.internal.Experimental
+import io.opentelemetry.instrumentation.ktor.v3_0.KtorClientTelemetry
 import opentelemetry.ktor.example.CUSTOM_HEADER
 import opentelemetry.ktor.example.CUSTOM_METHOD
 import opentelemetry.ktor.example.getOpenTelemetry
 
 /**
  * Install OpenTelemetry on the client.
- * You can see usages of new extension functions for [KtorClientTracing].
+ * You can see usages of new extension functions for [KtorClientTelemetry].
  */
 fun HttpClientConfig<CIOEngineConfig>.setupClientTelemetry() {
     val openTelemetry = getOpenTelemetry(serviceName = "opentelemetry-ktor-sample-client")
-    install(KtorClientTracing) {
+    install(KtorClientTelemetry) {
         setOpenTelemetry(openTelemetry)
 
-        emitExperimentalHttpClientMetrics()
+        Experimental.emitExperimentalTelemetry(this)
 
         knownMethods(HttpMethod.DefaultMethods + CUSTOM_METHOD)
         capturedRequestHeaders(HttpHeaders.Accept)
         capturedResponseHeaders(HttpHeaders.ContentType, CUSTOM_HEADER)
 
-        attributeExtractor {
+        attributesExtractor {
             onStart {
                 attributes.put("start-time", System.currentTimeMillis())
             }

--- a/opentelemetry/gradle.properties
+++ b/opentelemetry/gradle.properties
@@ -3,7 +3,7 @@ kotlin_version=2.1.20
 logback_version=1.5.12
 kotlin.code.style=official
 
-opentelemetry_version=2.10.0
-opentelemetry_semconv_version=1.21.0-alpha
-opentelemetry_exporter_otlp_version=1.44.1
-opentelemetry_sdk_extension_autoconfigure_version=1.44.1
+opentelemetry_version=2.14.0
+opentelemetry_semconv_version=1.30.0
+opentelemetry_exporter_otlp_version=1.48.0
+opentelemetry_sdk_extension_autoconfigure_version=1.48.0

--- a/opentelemetry/server/src/main/kotlin/opentelemetry/ktor/example/plugins/opentelemetry/setupServerTelemetry.kt
+++ b/opentelemetry/server/src/main/kotlin/opentelemetry/ktor/example/plugins/opentelemetry/setupServerTelemetry.kt
@@ -6,7 +6,7 @@ import io.ktor.server.request.*
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.StatusCode
-import io.opentelemetry.instrumentation.ktor.v3_0.server.KtorServerTracing
+import io.opentelemetry.instrumentation.ktor.v3_0.KtorServerTelemetry
 import opentelemetry.ktor.example.CUSTOM_HEADER
 import opentelemetry.ktor.example.CUSTOM_METHOD
 import opentelemetry.ktor.example.getOpenTelemetry
@@ -16,11 +16,11 @@ const val serviceName = "opentelemetry-ktor-sample-server"
 
 /**
  * Install OpenTelemetry on the server.
- * You can see usages of new extension functions for [KtorServerTracing].
+ * You can see usages of new extension functions for [KtorServerTelemetry].
  */
 fun Application.setupServerTelemetry(): OpenTelemetry {
     val openTelemetry = getOpenTelemetry(serviceName)
-    install(KtorServerTracing) {
+    install(KtorServerTelemetry) {
         setOpenTelemetry(openTelemetry)
 
         knownMethods(HttpMethod.DefaultMethods + CUSTOM_METHOD)
@@ -42,7 +42,7 @@ fun Application.setupServerTelemetry(): OpenTelemetry {
             }
         }
 
-        attributeExtractor {
+        attributesExtractor {
             onStart {
                 attributes.put("start-time", System.currentTimeMillis())
             }

--- a/opentelemetry/shared/src/main/kotlin/opentelemetry/ktor/example/utils.kt
+++ b/opentelemetry/shared/src/main/kotlin/opentelemetry/ktor/example/utils.kt
@@ -2,13 +2,13 @@ package opentelemetry.ktor.example
 
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
-import io.opentelemetry.semconv.ResourceAttributes
+import io.opentelemetry.semconv.ServiceAttributes
 
 fun getOpenTelemetry(serviceName: String): OpenTelemetry {
     return AutoConfiguredOpenTelemetrySdk.builder().addResourceCustomizer { oldResource, _ ->
         oldResource.toBuilder()
             .putAll(oldResource.attributes)
-            .put(ResourceAttributes.SERVICE_NAME, serviceName)
+            .put(ServiceAttributes.SERVICE_NAME, serviceName)
             .build()
     }.build().openTelemetrySdk
 }


### PR DESCRIPTION
Hi, I wanted to update the OpenTelemetry integration sample to match the most recent version. It seems to be working fine after running the example, as indicated in the README file.

One doubt that I have is whether `Experimental` is actually meant to be used here. It comes from an `internal` package, so I'm not entirely sure.